### PR TITLE
Add the CrossVersion.for3Use2_13 modifier to the readme instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Attempts to use `WeakReference` or `ReferenceQueue` will throw `ReferenceError`s
 Add the following dependency to your project settings:
 
 ```scala
-libraryDependencies += "org.scala-js" %%% "scalajs-weakreferences" % "1.0.0"
+libraryDependencies += ("org.scala-js" %%% "scalajs-weakreferences" % "1.0.0").cross(CrossVersion.for3Use2_13)
 ```
 
 When using a `crossProject`, add the above in `.jsSettings(...)`.


### PR DESCRIPTION
So that Scala 3 users can use it without having to figure it out themselves.